### PR TITLE
Extra sources for wxPython (speedup Linux build)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,10 @@ jobs:
             libsdl2-dev \
             libunwind-dev \
             libgtk2.0-dev
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
+      - name: Manually download wxPython wheel for Ubuntu 22.04 (prevents lengthy build)
+        run: $(poetry run which pip) install -U -f  https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython==4.2.1
+        if: matrix.os == 'ubuntu-22.04'
       - name: Installing Poetry environment
         run: poetry install
       - name: Setting tag to package version
@@ -75,10 +78,10 @@ jobs:
 
       - name: Authorize GitHub Actions to publish on PYPI
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
-        if: steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest'
+        if: steps.build.outcome == 'success' && matrix.os == 'ubuntu-22.04'
       - name: Publish on PYPI
         run: poetry publish
-        if: steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest'
+        if: steps.build.outcome == 'success' && matrix.os == 'ubuntu-22.04'
       - name: Make executable from wheel
         run: poetry run pyinstaller ./build.spec
         env:
@@ -99,7 +102,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Collect all artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN python3 -m venv $POETRY_HOME && $POETRY_HOME/bin/pip install poetry
 ENV PATH="/opt/poetry/bin:${PATH}"
 
 # Installing libretro_finder's deps
-#RUN poetry config installer.max-workers 10
-#RUN poetry install
+RUN poetry config installer.max-workers 10
+RUN poetry install
 
 # Default start
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.18-bookworm
+FROM python:3.9-bullseye
 
 # wxPython dependencies
 RUN apt-get update && apt install -y \
@@ -31,8 +31,8 @@ RUN python3 -m venv $POETRY_HOME && $POETRY_HOME/bin/pip install poetry
 ENV PATH="/opt/poetry/bin:${PATH}"
 
 # Installing libretro_finder's deps
-RUN poetry config installer.max-workers 10
-RUN poetry install
+#RUN poetry config installer.max-workers 10
+#RUN poetry install
 
 # Default start
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository does **NOT** include the BIOS files themselves.
 - Simple graphical user interface (GUI)
 - Scriptable command line interface (CLI)
 - Works on Windows, Linux and MacOS
-- Available through the Python Package Index (Python >=3.8) 
+- Available through the Python Package Index (Python >=3.9) 
 - Available as portable executable (no installation required)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -831,4 +831,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "53b9f0c73578ecfb2111449d81b390c18e3a8a26b479f0a5807b4feba1b96cc0"
+content-hash = "dbb28d276d33d89bdd919b39d66b9618c8435bb8c0fc09b295b8b97413d1ea4a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -831,4 +831,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "dbb28d276d33d89bdd919b39d66b9618c8435bb8c0fc09b295b8b97413d1ea4a"
+content-hash = "f82bcb27b3c5ef2ee6bf0444ab4b54a46078109748df44c38ed43cda214e3feb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -784,29 +784,12 @@ files = [
 ]
 
 [[package]]
-name = "wxpython"
+name = "wxPython"
 version = "4.2.1"
 description = "Cross platform GUI toolkit for Python, \"Phoenix\" version"
 optional = false
 python-versions = "*"
-files = [
-    {file = "wxPython-4.2.1-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:3fd606d10db694c29f712f13dc3d3179d0204a71f6c1fbb5fcee859d03e9ff97"},
-    {file = "wxPython-4.2.1-cp310-cp310-win32.whl", hash = "sha256:5b233c39d7bfb53b9c4928ee7c86d626f1f7a716a6dfc3acc152bb437e658751"},
-    {file = "wxPython-4.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:bb7988814e706eb00792589d606d317da5661dcffbb09263cd20da956c46bcbb"},
-    {file = "wxPython-4.2.1-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:e87960d1963e291d4009c8547c85716b7d5325eb828cd183fdb28d441d6c3787"},
-    {file = "wxPython-4.2.1-cp311-cp311-win32.whl", hash = "sha256:a41f3e03c3bfbe80864d7456f5c1236991fa937eedb60b986bd67e1bb47b7c3d"},
-    {file = "wxPython-4.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:3062b4d2f5d6dcf1d59983797fc067270a5ce829a918d52a516212e798f0c9ae"},
-    {file = "wxPython-4.2.1-cp312-cp312-macosx_10_10_universal2.whl", hash = "sha256:957a6e7cc68a8e4d7ca49c72a691b6efd5684040f4f03b112d0122e7ab470497"},
-    {file = "wxPython-4.2.1-cp312-cp312-win32.whl", hash = "sha256:8d846a785cd33c31e7eb42038eb159c88977d38208496b8322d14aef107f3eec"},
-    {file = "wxPython-4.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:1ca327c877f276b33e2c4b6cb8417964305ee505e2509fb2000851d48b82328f"},
-    {file = "wxPython-4.2.1-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:a7eefbc7fe7ac86479d814302711f8f118ba214229aa2a6d789fb888ee79abaa"},
-    {file = "wxPython-4.2.1-cp38-cp38-win32.whl", hash = "sha256:ff0423e84a5aaa203e7c1c3d36f8417c54cb4cd8849a43b3c917ac3bfafa4ad7"},
-    {file = "wxPython-4.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:903f45131107802b38c0b5d0e964a2ce0295b67e8c3d7659821ac5b26a35658b"},
-    {file = "wxPython-4.2.1-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:a15b76dad81f9bd6ceadf00fbede9aff9e09859a9aa698c53e8bd56b95d2effc"},
-    {file = "wxPython-4.2.1-cp39-cp39-win32.whl", hash = "sha256:c4db6d7f054d76cb1532dbd5da81b87b7a90dc9fdf18a3540063b2f8f5f3e663"},
-    {file = "wxPython-4.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:0595fdd133a552a232a99759b87891136a4500c806bbea68b888e7b6f2c9bbea"},
-    {file = "wxPython-4.2.1.tar.gz", hash = "sha256:e48de211a6606bf072ec3fa778771d6b746c00b7f4b970eb58728ddf56d13d5c"},
-]
+files = []
 
 [package.dependencies]
 numpy = {version = "*", markers = "python_version >= \"3.0\" and python_version < \"3.12\""}
@@ -831,4 +814,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "f82bcb27b3c5ef2ee6bf0444ab4b54a46078109748df44c38ed43cda214e3feb"
+content-hash = "88c465085343a4b7136c385cefd5d1ee9bf4c3c878f8b3de38d2a99b1960d0d7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -831,4 +831,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "3b03f074efef1526075ec124aa7bb34b8eef44bcc94671ea8dc4fa542fbb34a9"
+content-hash = "53b9f0c73578ecfb2111449d81b390c18e3a8a26b479f0a5807b4feba1b96cc0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,6 @@ packages = [
 [tool.poetry.scripts]
 libretro_finder = "libretro_finder.main:main"
 
-[[tool.poetry.source]]
-name = "extras-wxpython-2204"
-url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/"
-priority = "supplemental"
-
-[[tool.poetry.source]]
-name = "extras-wxpython-2004"
-url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/"
-priority = "supplemental"
-
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 gooey = "^1.0.8.1"
@@ -41,6 +31,17 @@ pytest-cov = "^4.1.0"
 pyinstaller = "^6.3.0"
 pandas-stubs = "^2.1.4.231218"
 types-tqdm = "^4.66.0.5"
+
+[[tool.poetry.source]]
+name = "extras-wxpython-2004"
+url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/"
+priority = "supplemental"
+
+
+[[tool.poetry.source]]
+name = "extras-wxpython-2204"
+url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/"
+priority = "supplemental"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libretro-finder"
-version = "0.3.0"
+version = "0.3.1"
 description = "Simple tool that finds and prepares your BIOS files for usage with Libretro (or its RetroArch frontend)."
 authors = ["Jasper Siebring <j.siebring92@gmail.com>"]
 license = "GNU General Public License v3.0"
@@ -14,12 +14,23 @@ packages = [
 [tool.poetry.scripts]
 libretro_finder = "libretro_finder.main:main"
 
+[[tool.poetry.source]]
+name = "extras-wxpython-2204"
+url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/"
+priority = "supplemental"
+
+[[tool.poetry.source]]
+name = "extras-wxpython-2004"
+url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/"
+priority = "supplemental"
+
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 gooey = "^1.0.8.1"
 pandas = "^2.1.4"
 tqdm = "^4.66.1"
 vdf = "^3.4"
+wxpython = "^4.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ gooey = "^1.0.8.1"
 pandas = "^2.1.4"
 tqdm = "^4.66.1"
 vdf = "^3.4"
-wxpython = "^4.2.1"
+wxpython = [
+    { version = "^4.2.1", source = "extras-wxpython-2204", platform = 'linux' },
+    { version = "^4.2.1", source = "pypi", platform = 'win32' }
+]
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
@@ -33,15 +37,13 @@ pandas-stubs = "^2.1.4.231218"
 types-tqdm = "^4.66.0.5"
 
 [[tool.poetry.source]]
-name = "extras-wxpython-2004"
-url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/"
-priority = "supplemental"
-
-
-[[tool.poetry.source]]
 name = "extras-wxpython-2204"
 url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/"
-priority = "supplemental"
+priority = "explicit"
+
+[[tool.poetry.source]]
+name = "pypi"
+priority = "primary"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,7 @@ gooey = "^1.0.8.1"
 pandas = "^2.1.4"
 tqdm = "^4.66.1"
 vdf = "^3.4"
-wxpython = [
-    { version = "^4.2.1", source = "extras-wxpython-2204", platform = 'linux' },
-    { version = "^4.2.1", source = "pypi", platform = 'win32' }
-]
-
+wxpython = "^4.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
@@ -35,15 +31,6 @@ pytest-cov = "^4.1.0"
 pyinstaller = "^6.3.0"
 pandas-stubs = "^2.1.4.231218"
 types-tqdm = "^4.66.0.5"
-
-[[tool.poetry.source]]
-name = "extras-wxpython-2204"
-url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/"
-priority = "explicit"
-
-[[tool.poetry.source]]
-name = "pypi"
-priority = "primary"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
For reasons disclosed [here](https://wxpython.org/pages/downloads/index.html), pypi has no wheels available for wxPython on Linux. This causes Linux builds to take up to 25 minutes (against the ~2 minutes on Windows/MacOS) which is a bit annoying.

We circumvent this by manually specifying a prebuilt wxPython=4.2.1 wheel for Ubuntu 22.04 and installing it in the poetry venv before we call `poetry install`. Bit finicky but this will be fine for as long as we use Ubuntu 22.04 runners for CI and wxPython 4.2.1.





